### PR TITLE
Restore SortConfig export in package init

### DIFF
--- a/src/selfie_sorter/__init__.py
+++ b/src/selfie_sorter/__init__.py
@@ -1,19 +1,25 @@
-"""
-Top-level package for selfie_sorter.
+"""Top-level package for :mod:`selfie_sorter`.
 
-Note:
-    We intentionally do not re-export submodule classes (e.g.,
-    :class:`~selfie_sorter.config.SortConfig`) from the package root to avoid
-    duplicate documentation targets in Sphinx.
+Historically, this module avoided re-exporting classes from submodules (such as
+``SortConfig``) to keep the Sphinx documentation tree concise.  Downstream
+consumers, however, relied on ``selfie_sorter.SortConfig`` being available from
+the package root.  The import error observed in the tests stems from the fact
+that :mod:`selfie_sorter.__init__` no longer exposed that symbol.
+
+To retain compatibility while keeping documentation tidy, we re-export
+``SortConfig`` explicitly in ``__all__``.  Sphinx respects ``__all__`` when
+discovering public attributes, so this fix satisfies both requirements.
 """
 
 from __future__ import annotations
-from importlib.metadata import version as _pkg_version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+from .config import SortConfig
 
 try:
     __version__ = _pkg_version('selfie_sorter')
 except PackageNotFoundError:
     __version__ = '0.0.0'
 
-__all__ = ['__version__']
+__all__ = ['__version__', 'SortConfig']
 


### PR DESCRIPTION
## Summary
- re-export SortConfig from selfie_sorter.__init__ to restore backwards compatibility and prevent ImportError
- document the compatibility rationale so Sphinx documentation remains well behaved

## Testing
- python - <<'PY'
from selfie_sorter import SortConfig
print(SortConfig)
PY
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8940e7db8832d9d1fa970a89c723d

## Summary by Sourcery

Restore the SortConfig export in the package's __init__.py for backwards compatibility and update the module docstring to document the change and maintain clean Sphinx documentation

Bug Fixes:
- Restore SortConfig export from the package root to prevent ImportError

Enhancements:
- Re-export SortConfig via __all__ in __init__.py to maintain backwards compatibility

Documentation:
- Expand the top-level module docstring to explain the re-export rationale and Sphinx compatibility