### PR TITLE
Allow providing explicit file list to sorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ and sub-folders by detected label (e.g., `female_breast_exposed`) using:
 # with Poetry
 poetry install
 poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted"
+# or explicitly list files to process instead of scanning the input tree
+poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --files \
+  "/path/to/unsorted/a.jpg" \
+  "/path/to/unsorted/subdir/b.png"
 
 # OR without Poetry (you provide exiftool on your PATH):
 pip install pillow imagehash nudenet opennsfw2

--- a/src/selfie_sorter/cli.py
+++ b/src/selfie_sorter/cli.py
@@ -36,6 +36,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument('--in', dest='root_in', required=True, type=Path, help='Input directory')
     p.add_argument('--out', dest='root_out', required=True, type=Path, help='Output directory')
+    p.add_argument(
+        '--files',
+        dest='input_files',
+        type=Path,
+        nargs='+',
+        help='Optional explicit list of image files to process instead of scanning the input directory',
+    )
     p.add_argument('--no-coarse', action='store_true', help='Disable OpenNSFW2 gate')
     p.add_argument('--nsfw-threshold', type=float, default=0.80)
     p.add_argument('--keep-safe', action='store_true', help='Keep safe images in place (do not move)')
@@ -70,6 +77,7 @@ def main() -> None:
         move_safe=not a.keep_safe,
         strip_metadata=not a.no_exif_strip,
         dup_hamming=a.dup_hamming,
+        input_files=tuple(a.input_files) if a.input_files else None,
     )
     SelfieSorter(cfg).run()
 

--- a/src/selfie_sorter/config.py
+++ b/src/selfie_sorter/config.py
@@ -9,7 +9,7 @@ metadata handling, and more.
 """
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 from .constants import EXPLICIT_RULES, SUGGESTIVE_RULES
 
@@ -72,6 +72,7 @@ class SortConfig:
     dir_safe: str = 'safe'
     dir_dupes: str = 'dupes'
     exiftool_cmd: str = 'exiftool'
+    input_files: Optional[Tuple[Path, ...]] = None
 
 
 __all__ = [

--- a/src/selfie_sorter/sorter.py
+++ b/src/selfie_sorter/sorter.py
@@ -82,10 +82,14 @@ class SelfieSorter:
         """
         if self.cfg.input_files:
             files: List[Path] = []
+            seen: set = set()
             for candidate in self.cfg.input_files:
                 path = Path(candidate)
-                if path.is_file() and path.suffix.lower() in self.IMAGE_EXTS:
+                # Use absolute path for deduplication
+                abs_path = path.resolve()
+                if abs_path not in seen and path.is_file() and path.suffix.lower() in self.IMAGE_EXTS:
                     files.append(path)
+                    seen.add(abs_path)
         else:
             files = [
                 p for p in self.cfg.root_in.rglob('*')

--- a/src/selfie_sorter/sorter.py
+++ b/src/selfie_sorter/sorter.py
@@ -80,10 +80,17 @@ class SelfieSorter:
         Returns:
             None
         """
-        files: List[Path] = [
-            p for p in self.cfg.root_in.rglob('*')
-            if p.is_file() and p.suffix.lower() in self.IMAGE_EXTS
-        ]
+        if self.cfg.input_files:
+            files: List[Path] = []
+            for candidate in self.cfg.input_files:
+                path = Path(candidate)
+                if path.is_file() and path.suffix.lower() in self.IMAGE_EXTS:
+                    files.append(path)
+        else:
+            files = [
+                p for p in self.cfg.root_in.rglob('*')
+                if p.is_file() and p.suffix.lower() in self.IMAGE_EXTS
+            ]
         for path in files:
             try:
                 self._process_one(path)


### PR DESCRIPTION
## Summary
- add an optional `--files` CLI flag that forwards explicit image paths to the sorter
- plumb the optional file list through the configuration and sorter so scanning can be skipped
- document the new invocation style in the README

## Testing
- python -m selfie_sorter.cli --help

------
https://chatgpt.com/codex/tasks/task_e_68d895bf7268832d9ba4db50bfde482d

## Summary by Sourcery

Allow users to specify an explicit list of image files for sorting via a new --files flag, bypass directory scanning when provided, and update the README to reflect this usage.

New Features:
- Add --files CLI flag to accept an explicit list of image files to process

Enhancements:
- Pass the provided file list through the configuration to the sorter and skip directory scanning when files are specified

Documentation:
- Document the new --files invocation style in the README