### PR TITLE
Add configurable censor styles for generated copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor
 # store censored copies in a custom directory (relative paths resolve under --out)
 poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor-copies \
   --censor-dir shared_censors
+# disable the progress spinner/bar for minimal console output
+poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --no-progress
 # pick a different censor style (blurred or a black box with a label)
 poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor-copies \
   --censor-style blurred
@@ -45,4 +47,5 @@ python -m selfie_sorter.cli --in "/path/to/unsorted" --out "/path/to/sorted"
   `--censor-dir` to redirect the censored tree elsewhere (relative paths resolve under `--out`).
 - Run `--censor-existing /path/to/sorted` to read previously generated JSON sidecars, crop censorship to the
   recorded bounding boxes, and emit new copies suffixed with `_censored` (override with `--censor-suffix`). By default
-  the censored tree is written to `<root>/censored`; combine with `--censor-dir` to change the destination.
+  the censored tree is written to `<root>/censored`; combine with `--censor-dir` to change the destination. Long-running
+  operations display a spinner and progress bar powered by `yaspin`/`tqdm`; add `--no-progress` to opt out.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor
 # pick a different censor style (blurred or a black box with a label)
 poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor-copies \
   --censor-style blurred
+# retroactively generate censored copies from an already-sorted tree
+poetry run selfie-sort --censor-existing "/path/to/sorted" --censor-style black-box \
+  --censor-label "CENSORED" --censor-strength 32
 
 # OR without Poetry (you provide exiftool on your PATH):
 pip install pillow imagehash nudenet opennsfw2
@@ -35,4 +38,6 @@ python -m selfie_sorter.cli --in "/path/to/unsorted" --out "/path/to/sorted"
 - Use `--dup-hamming` to tune near-duplicate sensitivity (default 5).
 - Enable `--censor-copies` to write censored siblings for sharing. Use `--censor-style` to choose between
   `pixelated`, `blurred`, or `black-box`, adjust intensity with `--censor-strength`, and change the
-  overlay text (for `black-box`) via `--censor-label`.
+  overlay text (for `black-box`) via `--censor-label` (supports `{label}` placeholder for the detection label).
+- Run `--censor-existing /path/to/sorted` to read previously generated JSON sidecars, crop censorship to the
+  recorded bounding boxes, and emit new copies suffixed with `_censored` (override with `--censor-suffix`).

--- a/README.md
+++ b/README.md
@@ -17,14 +17,17 @@ poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted"
 poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --files \
   "/path/to/unsorted/a.jpg" \
   "/path/to/unsorted/subdir/b.png"
-# add censored copies alongside the sorted files (pixelated by default)
+# add censored copies organized under <out>/censored (pixelated by default)
 poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor-copies
+# store censored copies in a custom directory (relative paths resolve under --out)
+poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor-copies \
+  --censor-dir shared_censors
 # pick a different censor style (blurred or a black box with a label)
 poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor-copies \
   --censor-style blurred
 # retroactively generate censored copies from an already-sorted tree
 poetry run selfie-sort --censor-existing "/path/to/sorted" --censor-style black-box \
-  --censor-label "CENSORED" --censor-strength 32
+  --censor-label "CENSORED" --censor-strength 32 --censor-dir retro_censored
 
 # OR without Poetry (you provide exiftool on your PATH):
 pip install pillow imagehash nudenet opennsfw2
@@ -36,8 +39,10 @@ python -m selfie_sorter.cli --in "/path/to/unsorted" --out "/path/to/sorted"
 - Rules are normalized to UPPERCASE_WITH_UNDERSCORES for robust matching.
 - Set `--no-coarse` to skip OpenNSFW2 gate.
 - Use `--dup-hamming` to tune near-duplicate sensitivity (default 5).
-- Enable `--censor-copies` to write censored siblings for sharing. Use `--censor-style` to choose between
+- Enable `--censor-copies` to write censored versions under `<out>/censored`. Use `--censor-style` to choose between
   `pixelated`, `blurred`, or `black-box`, adjust intensity with `--censor-strength`, and change the
-  overlay text (for `black-box`) via `--censor-label` (supports `{label}` placeholder for the detection label).
+  overlay text (for `black-box`) via `--censor-label` (supports `{label}` placeholder for the detection label). Use
+  `--censor-dir` to redirect the censored tree elsewhere (relative paths resolve under `--out`).
 - Run `--censor-existing /path/to/sorted` to read previously generated JSON sidecars, crop censorship to the
-  recorded bounding boxes, and emit new copies suffixed with `_censored` (override with `--censor-suffix`).
+  recorded bounding boxes, and emit new copies suffixed with `_censored` (override with `--censor-suffix`). By default
+  the censored tree is written to `<root>/censored`; combine with `--censor-dir` to change the destination.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ and sub-folders by detected label (e.g., `female_breast_exposed`) using:
 # with Poetry
 poetry install
 poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted"
+# or explicitly list files to process instead of scanning the input tree
+poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --files \
+  "/path/to/unsorted/a.jpg" \
+  "/path/to/unsorted/subdir/b.png"
+# add censored copies alongside the sorted files (pixelated by default)
+poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor-copies
+# pick a different censor style (blurred or a black box with a label)
+poetry run selfie-sort --in "/path/to/unsorted" --out "/path/to/sorted" --censor-copies \
+  --censor-style blurred
 
 # OR without Poetry (you provide exiftool on your PATH):
 pip install pillow imagehash nudenet opennsfw2
@@ -24,3 +33,6 @@ python -m selfie_sorter.cli --in "/path/to/unsorted" --out "/path/to/sorted"
 - Rules are normalized to UPPERCASE_WITH_UNDERSCORES for robust matching.
 - Set `--no-coarse` to skip OpenNSFW2 gate.
 - Use `--dup-hamming` to tune near-duplicate sensitivity (default 5).
+- Enable `--censor-copies` to write censored siblings for sharing. Use `--censor-style` to choose between
+  `pixelated`, `blurred`, or `black-box`, adjust intensity with `--censor-strength`, and change the
+  overlay text (for `black-box`) via `--censor-label`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "selfie-sorter"
-version = "1.0.0-dev.2"
+version = "1.0.0-dev.3"
 description = "Local selfie sorter that files images by explicit/suggestive labels using NudeNet + OpenNSFW2"
 authors = ["Taylor <t.blackstone@inspyre.tech>"]
 readme = "README.md"
@@ -30,4 +30,9 @@ docs = [
     "sphinx-copybutton (>=0.5.2,<0.6.0)",
     "sphinx-design (>=0.6.1,<0.7.0)",
     "myst-parser (>=4.0.1,<5.0.0)"
+]
+dev = [
+    "ipython (>=9.5.0,<10.0.0)",
+    "prompt-toolkit (>=3.0.52,<4.0.0)",
+    "ptipython (>=1.0.1,<2.0.0)"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ pillow = "*"
 imagehash = "*"
 nudenet = "*"
 opennsfw2 = "*"
+tqdm = "*"
+yaspin = "*"
 
 [tool.poetry.scripts]
 selfie-sort = "selfie_sorter.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pillow
 imagehash
 nudenet
 opennsfw2
+tqdm
+yaspin

--- a/src/selfie_sorter/censor.py
+++ b/src/selfie_sorter/censor.py
@@ -2,10 +2,32 @@
 
 from __future__ import annotations
 
+import json
+import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 from PIL import Image, ImageDraw, ImageFilter, ImageFont
+
+from .constants import IMAGE_EXTS
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CensorBox:
+    """Normalized description of a censor region."""
+
+    left: int
+    top: int
+    right: int
+    bottom: int
+    label: Optional[str] = None
+
+    def as_tuple(self) -> Tuple[int, int, int, int]:
+        return (self.left, self.top, self.right, self.bottom)
 
 
 class ImageCensor:
@@ -23,7 +45,14 @@ class ImageCensor:
         self.strength = strength
         self.label = label
 
-    def create_copy(self, source: Path, destination: Optional[Path] = None) -> Path:
+    def create_copy(
+        self,
+        source: Path,
+        destination: Optional[Path] = None,
+        *,
+        boxes: Optional[Sequence[Tuple[int, int, int, int]]] = None,
+        detections: Optional[Sequence[object]] = None,
+    ) -> Path:
         """Write a censored copy of ``source`` to ``destination``.
 
         Parameters
@@ -33,6 +62,11 @@ class ImageCensor:
         destination:
             Optional output path.  When omitted a sibling file suffixed with
             ``_censored`` is produced.
+        boxes:
+            Optional sequence of explicit pixel coordinates ``(left, top, right, bottom)``
+            that should be censored.
+        detections:
+            Optional NudeNet-style detection dictionaries used to derive censor boxes.
         """
         if not source.is_file():
             raise ValueError(f'Not a file: {source!s}')
@@ -44,47 +78,214 @@ class ImageCensor:
 
         with Image.open(source) as image:
             image.load()
-            censored = self._apply(image)
+            resolved = self._resolve_boxes(image.size, boxes=boxes, detections=detections)
+            censored = self._apply(image, resolved)
             censored.save(destination)
 
         return destination
 
-    def _apply(self, image: Image.Image) -> Image.Image:
+    def _resolve_boxes(
+        self,
+        size: Tuple[int, int],
+        *,
+        boxes: Optional[Sequence[Tuple[int, int, int, int]]] = None,
+        detections: Optional[Sequence[object]] = None,
+    ) -> List[CensorBox]:
+        width, height = size
+        resolved: List[CensorBox] = []
+
+        if boxes:
+            for box in boxes:
+                normalized = self._normalize_box(tuple(box), width, height)
+                if normalized:
+                    resolved.append(CensorBox(*normalized))
+
+        if not resolved and detections:
+            for det in detections:
+                if not isinstance(det, dict):
+                    continue
+                raw_box = det.get('box') or det.get('bbox') or det.get('rect')
+                if not raw_box:
+                    continue
+                normalized = self._normalize_box(tuple(raw_box), width, height)
+                if not normalized:
+                    continue
+                label = det.get('label') or det.get('class')
+                resolved.append(CensorBox(*normalized, label=label))
+
+        return resolved
+
+    @staticmethod
+    def _normalize_box(box: Tuple[float, float, float, float], width: int, height: int) -> Optional[Tuple[int, int, int, int]]:
+        if len(box) != 4:
+            return None
+
+        x1, y1, x2, y2 = box
+
+        def clamp(val: float, upper: int) -> int:
+            return max(0, min(int(round(val)), upper))
+
+        # Determine whether the box is normalized (0-1) or absolute coordinates.
+        normalized = all(0.0 <= coord <= 1.0 for coord in box)
+        if normalized:
+            if x2 <= 1.0 and x2 <= x1:
+                x2 = x1 + max(0.0, x2)
+            if y2 <= 1.0 and y2 <= y1:
+                y2 = y1 + max(0.0, y2)
+            x1 *= width
+            x2 *= width
+            y1 *= height
+            y2 *= height
+        else:
+            if x2 <= x1:
+                x2 = x1 + max(0.0, x2)
+            if y2 <= y1:
+                y2 = y1 + max(0.0, y2)
+
+        left = clamp(x1, width)
+        top = clamp(y1, height)
+        right = clamp(x2, width)
+        bottom = clamp(y2, height)
+
+        if right - left <= 1 or bottom - top <= 1:
+            return None
+
+        return (left, top, right, bottom)
+
+    def _apply(self, image: Image.Image, boxes: Sequence[CensorBox]) -> Image.Image:
+        if not boxes:
+            if self.style == 'pixelated':
+                return self._pixelate_region(image, (0, 0, image.width, image.height))
+            if self.style == 'blurred':
+                return image.filter(ImageFilter.GaussianBlur(radius=self.strength))
+            return self._black_box_regions(image, [CensorBox(0, 0, image.width, image.height, self.label)])
+
         if self.style == 'pixelated':
-            return self._pixelate(image)
+            return self._apply_pixelate(image, boxes)
         if self.style == 'blurred':
-            return image.filter(ImageFilter.GaussianBlur(radius=self.strength))
-        return self._black_box(image)
+            return self._apply_blur(image, boxes)
+        return self._black_box_regions(image, boxes)
 
-    def _pixelate(self, image: Image.Image) -> Image.Image:
-        shrink_w = max(1, image.width // self.strength)
-        shrink_h = max(1, image.height // self.strength)
-        censored = image.resize((shrink_w, shrink_h), Image.BILINEAR)
-        return censored.resize(image.size, Image.NEAREST)
+    def _apply_pixelate(self, image: Image.Image, boxes: Sequence[CensorBox]) -> Image.Image:
+        censored = image.copy()
+        for box in boxes:
+            region = self._pixelate_region(image, box.as_tuple())
+            censored.paste(region, (box.left, box.top))
+        return censored
 
-    def _black_box(self, image: Image.Image) -> Image.Image:
+    def _pixelate_region(self, image: Image.Image, box: Tuple[int, int, int, int]) -> Image.Image:
+        left, top, right, bottom = box
+        region = image.crop((left, top, right, bottom))
+        shrink_w = max(1, region.width // self.strength)
+        shrink_h = max(1, region.height // self.strength)
+        small = region.resize((shrink_w, shrink_h), Image.BILINEAR)
+        return small.resize(region.size, Image.NEAREST)
+
+    def _apply_blur(self, image: Image.Image, boxes: Sequence[CensorBox]) -> Image.Image:
+        censored = image.copy()
+        for box in boxes:
+            left, top, right, bottom = box.as_tuple()
+            region = image.crop((left, top, right, bottom))
+            blurred = region.filter(ImageFilter.GaussianBlur(radius=self.strength))
+            censored.paste(blurred, (left, top))
+        return censored
+
+    def _black_box_regions(self, image: Image.Image, boxes: Sequence[CensorBox]) -> Image.Image:
         censored = image.copy()
         draw = ImageDraw.Draw(censored, 'RGBA')
-        margin = max(0, min(image.size) // 20)
-        box_height = max(self.strength, image.height // 3)
-        top = max(margin, (image.height - box_height) // 2)
-        bottom = min(image.height - margin, top + box_height)
-        draw.rectangle(
-            [(margin, top), (image.width - margin, bottom)],
-            fill=(0, 0, 0, 255),
-        )
-        if self.label:
-            font = ImageFont.load_default()
-            try:
-                text_bbox = draw.textbbox((0, 0), self.label, font=font)
-                text_w = text_bbox[2] - text_bbox[0]
-                text_h = text_bbox[3] - text_bbox[1]
-            except AttributeError:  # pragma: no cover - Pillow < 8 compatibility
-                text_w, text_h = draw.textsize(self.label, font=font)
-            text_x = (image.width - text_w) / 2
-            text_y = top + (box_height - text_h) / 2
-            draw.text((text_x, text_y), self.label, fill='white', font=font)
+        font = ImageFont.load_default() if self.label else None
+        for box in boxes:
+            left, top, right, bottom = box.as_tuple()
+            draw.rectangle([(left, top), (right, bottom)], fill=(0, 0, 0, 255))
+            text = self.label
+            if text and '{label}' in text:
+                text = text.format(label=box.label or '')
+            if text and font:
+                try:
+                    text_bbox = draw.textbbox((0, 0), text, font=font)
+                    text_w = text_bbox[2] - text_bbox[0]
+                    text_h = text_bbox[3] - text_bbox[1]
+                except AttributeError:  # pragma: no cover - Pillow < 8 compatibility
+                    text_w, text_h = draw.textsize(text, font=font)
+                text_x = left + (right - left - text_w) / 2
+                text_y = top + (bottom - top - text_h) / 2
+                draw.text((text_x, text_y), text, fill='white', font=font)
         return censored
 
 
-__all__ = ['ImageCensor']
+def censor_sorted_tree(
+    root: Path,
+    *,
+    censor: ImageCensor,
+    suffix: str = '_censored',
+    image_exts: Iterable[str] = IMAGE_EXTS,
+) -> List[Path]:
+    """Generate censored copies for images that already have NudeNet metadata.
+
+    Parameters
+    ----------
+    root:
+        Directory containing sorted images and JSON sidecars.
+    censor:
+        Configured :class:`ImageCensor` instance.
+    suffix:
+        Suffix appended to the generated filenames.
+    image_exts:
+        Iterable of supported image extensions.
+    """
+
+    root = Path(root)
+    if not root.is_dir():
+        raise ValueError(f'Not a directory: {root!s}')
+
+    created: List[Path] = []
+    normalized_exts = {ext.lower() for ext in image_exts}
+
+    for image_path in sorted(root.rglob('*')):
+        if image_path.suffix.lower() not in normalized_exts:
+            continue
+
+        sidecar = image_path.with_suffix(image_path.suffix + '.json')
+        if not sidecar.exists():
+            logger.warning('Skipping %s: missing sidecar %s', image_path, sidecar.name)
+            continue
+
+        try:
+            with open(sidecar, 'r', encoding='utf-8') as fh:
+                metadata = json.load(fh)
+        except Exception:
+            logger.warning('Skipping %s: failed to parse %s', image_path, sidecar.name, exc_info=True)
+            continue
+
+        detections = metadata.get('detections') or []
+        if not detections:
+            logger.info('Skipping %s: no detections recorded', image_path)
+            continue
+
+        destination = _unique_destination(
+            image_path.with_name(f'{image_path.stem}{suffix}{image_path.suffix}')
+        )
+        try:
+            censor.create_copy(image_path, destination, detections=detections)
+        except Exception:
+            logger.warning('Failed to create censored copy for %s', image_path, exc_info=True)
+            continue
+
+        created.append(destination)
+
+    return created
+
+
+def _unique_destination(base: Path) -> Path:
+    if not base.exists():
+        return base
+    stem, ext = base.stem, base.suffix
+    counter = 1
+    candidate = base
+    while candidate.exists():
+        candidate = base.with_name(f'{stem}_{counter}{ext}')
+        counter += 1
+    return candidate
+
+
+__all__ = ['CensorBox', 'ImageCensor', 'censor_sorted_tree']

--- a/src/selfie_sorter/censor.py
+++ b/src/selfie_sorter/censor.py
@@ -1,0 +1,90 @@
+"""Utility helpers for generating censored image copies."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image, ImageDraw, ImageFilter, ImageFont
+
+
+class ImageCensor:
+    """Create censored copies of images for safer sharing."""
+
+    _VALID_STYLES = {'pixelated', 'blurred', 'black_box'}
+
+    def __init__(self, *, style: str = 'pixelated', strength: int = 12, label: str = 'CENSORED') -> None:
+        normalized = style.lower().replace('-', '_')
+        if normalized not in self._VALID_STYLES:
+            raise ValueError(f'Unsupported censor style: {style!r}')
+        if strength < 1:
+            raise ValueError('strength must be >= 1')
+        self.style = normalized
+        self.strength = strength
+        self.label = label
+
+    def create_copy(self, source: Path, destination: Optional[Path] = None) -> Path:
+        """Write a censored copy of ``source`` to ``destination``.
+
+        Parameters
+        ----------
+        source:
+            Original image that has already been sorted.
+        destination:
+            Optional output path.  When omitted a sibling file suffixed with
+            ``_censored`` is produced.
+        """
+        if not source.is_file():
+            raise ValueError(f'Not a file: {source!s}')
+
+        if destination is None:
+            destination = source.with_name(f'{source.stem}_censored{source.suffix}')
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        with Image.open(source) as image:
+            image.load()
+            censored = self._apply(image)
+            censored.save(destination)
+
+        return destination
+
+    def _apply(self, image: Image.Image) -> Image.Image:
+        if self.style == 'pixelated':
+            return self._pixelate(image)
+        if self.style == 'blurred':
+            return image.filter(ImageFilter.GaussianBlur(radius=self.strength))
+        return self._black_box(image)
+
+    def _pixelate(self, image: Image.Image) -> Image.Image:
+        shrink_w = max(1, image.width // self.strength)
+        shrink_h = max(1, image.height // self.strength)
+        censored = image.resize((shrink_w, shrink_h), Image.BILINEAR)
+        return censored.resize(image.size, Image.NEAREST)
+
+    def _black_box(self, image: Image.Image) -> Image.Image:
+        censored = image.copy()
+        draw = ImageDraw.Draw(censored, 'RGBA')
+        margin = max(0, min(image.size) // 20)
+        box_height = max(self.strength, image.height // 3)
+        top = max(margin, (image.height - box_height) // 2)
+        bottom = min(image.height - margin, top + box_height)
+        draw.rectangle(
+            [(margin, top), (image.width - margin, bottom)],
+            fill=(0, 0, 0, 255),
+        )
+        if self.label:
+            font = ImageFont.load_default()
+            try:
+                text_bbox = draw.textbbox((0, 0), self.label, font=font)
+                text_w = text_bbox[2] - text_bbox[0]
+                text_h = text_bbox[3] - text_bbox[1]
+            except AttributeError:  # pragma: no cover - Pillow < 8 compatibility
+                text_w, text_h = draw.textsize(self.label, font=font)
+            text_x = (image.width - text_w) / 2
+            text_y = top + (box_height - text_h) / 2
+            draw.text((text_x, text_y), self.label, fill='white', font=font)
+        return censored
+
+
+__all__ = ['ImageCensor']

--- a/src/selfie_sorter/cli.py
+++ b/src/selfie_sorter/cli.py
@@ -36,11 +36,36 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument('--in', dest='root_in', required=True, type=Path, help='Input directory')
     p.add_argument('--out', dest='root_out', required=True, type=Path, help='Output directory')
+    p.add_argument(
+        '--files',
+        dest='input_files',
+        type=Path,
+        nargs='+',
+        help='Optional explicit list of image files to process instead of scanning the input directory',
+    )
     p.add_argument('--no-coarse', action='store_true', help='Disable OpenNSFW2 gate')
     p.add_argument('--nsfw-threshold', type=float, default=0.80)
     p.add_argument('--keep-safe', action='store_true', help='Keep safe images in place (do not move)')
     p.add_argument('--no-exif-strip', action='store_true', help='Do not remove metadata')
     p.add_argument('--dup-hamming', type=int, default=5)
+    p.add_argument('--censor-copies', action='store_true', help='Write a censored copy beside each moved file')
+    p.add_argument(
+        '--censor-style',
+        choices=['pixelated', 'blurred', 'black-box'],
+        default='pixelated',
+        help='Censoring style to apply to generated copies',
+    )
+    p.add_argument(
+        '--censor-strength',
+        type=int,
+        default=12,
+        help='Intensity of the censoring effect (block size, blur radius, or box height)',
+    )
+    p.add_argument(
+        '--censor-label',
+        default='CENSORED',
+        help='Text drawn inside black-box censor copies (ignored for other styles)',
+    )
     return p
 
 
@@ -70,6 +95,11 @@ def main() -> None:
         move_safe=not a.keep_safe,
         strip_metadata=not a.no_exif_strip,
         dup_hamming=a.dup_hamming,
+        input_files=tuple(a.input_files) if a.input_files else None,
+        write_censored=a.censor_copies,
+        censor_style=a.censor_style.replace('-', '_'),
+        censor_strength=a.censor_strength,
+        censor_label=a.censor_label,
     )
     SelfieSorter(cfg).run()
 

--- a/src/selfie_sorter/cli.py
+++ b/src/selfie_sorter/cli.py
@@ -50,6 +50,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--dup-hamming', type=int, default=5)
     p.add_argument('--censor-copies', action='store_true', help='Write a censored copy beside each moved file')
     p.add_argument(
+        '--no-progress',
+        action='store_true',
+        help='Disable the spinner and progress bar for batch operations',
+    )
+    p.add_argument(
         '--censor-style',
         choices=['pixelated', 'blurred', 'black-box'],
         default='pixelated',
@@ -118,6 +123,7 @@ def main() -> None:
             censor=censor,
             suffix=a.censor_suffix,
             output_root=output_root,
+            show_progress=not a.no_progress,
         )
         if not created:
             print('No censored files were generated.')
@@ -142,6 +148,7 @@ def main() -> None:
         censor_strength=a.censor_strength,
         censor_label=a.censor_label,
         censored_suffix=a.censor_suffix,
+        show_progress=not a.no_progress,
     )
     if a.censor_dir is not None:
         cfg_kwargs['censored_root'] = a.censor_dir

--- a/src/selfie_sorter/config.py
+++ b/src/selfie_sorter/config.py
@@ -72,6 +72,7 @@ class SortConfig:
     censor_label:     str             = 'CENSORED'
     censored_suffix:  str             = '_censored'
     censored_root:    Path            = Path('censored')
+    show_progress:    bool            = True
 
     dir_explicit: str = 'explicit'
     dir_suggestive: str = 'suggestive'

--- a/src/selfie_sorter/config.py
+++ b/src/selfie_sorter/config.py
@@ -9,7 +9,7 @@ metadata handling, and more.
 """
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 from .constants import EXPLICIT_RULES, SUGGESTIVE_RULES
 
@@ -66,12 +66,18 @@ class SortConfig:
     strip_metadata:   bool            = True
     write_sidecar:    bool            = True
     move_safe:        bool            = False
+    write_censored:   bool            = False
+    censor_style:     str             = 'pixelated'
+    censor_strength:  int             = 12
+    censor_label:     str             = 'CENSORED'
+    censored_suffix:  str             = '_censored'
 
     dir_explicit: str = 'explicit'
     dir_suggestive: str = 'suggestive'
     dir_safe: str = 'safe'
     dir_dupes: str = 'dupes'
     exiftool_cmd: str = 'exiftool'
+    input_files: Optional[Tuple[Path, ...]] = None
 
 
 __all__ = [

--- a/src/selfie_sorter/config.py
+++ b/src/selfie_sorter/config.py
@@ -71,6 +71,7 @@ class SortConfig:
     censor_strength:  int             = 12
     censor_label:     str             = 'CENSORED'
     censored_suffix:  str             = '_censored'
+    censored_root:    Path            = Path('censored')
 
     dir_explicit: str = 'explicit'
     dir_suggestive: str = 'suggestive'

--- a/src/selfie_sorter/sorter.py
+++ b/src/selfie_sorter/sorter.py
@@ -16,7 +16,8 @@ from pathlib import Path
 import json
 import shutil
 import hashlib
-from typing import List
+import logging
+from typing import Iterable, List, Set
 
 from .constants import IMAGE_EXTS
 from .config import SortConfig
@@ -25,6 +26,10 @@ from .detector import FineDetector
 from .router import TagRouter
 from .dedupe import Deduper
 from .metadata import MetadataCleaner
+from .censor import ImageCensor
+
+
+logger = logging.getLogger(__name__)
 
 
 class SelfieSorter:
@@ -53,6 +58,15 @@ class SelfieSorter:
         self.router = TagRouter(cfg)
         self.dedupe = Deduper(cfg)
         self.cleaner = MetadataCleaner(cfg)
+        self.censor = (
+            ImageCensor(
+                style=cfg.censor_style,
+                strength=cfg.censor_strength,
+                label=cfg.censor_label,
+            )
+            if cfg.write_censored
+            else None
+        )
 
         for d in [cfg.dir_explicit, cfg.dir_suggestive, cfg.dir_safe, cfg.dir_dupes]:
             (cfg.root_out / d).mkdir(parents=True, exist_ok=True)
@@ -80,10 +94,7 @@ class SelfieSorter:
         Returns:
             None
         """
-        files: List[Path] = [
-            p for p in self.cfg.root_in.rglob('*')
-            if p.is_file() and p.suffix.lower() in self.IMAGE_EXTS
-        ]
+        files = self._gather_files()
         for path in files:
             try:
                 self._process_one(path)
@@ -91,6 +102,52 @@ class SelfieSorter:
                 raise
             except Exception:
                 continue
+
+    def _gather_files(self) -> List[Path]:
+        """Collect supported files from explicit input or by scanning root_in."""
+        if self.cfg.input_files:
+            files = self._filter_supported_files(self.cfg.input_files, dedupe=True, log_skips=True)
+        else:
+            files = self._filter_supported_files(self.cfg.root_in.rglob('*'))
+        return sorted(files, key=lambda p: str(p).lower())
+
+    def _filter_supported_files(
+        self,
+        candidates: Iterable[Path],
+        *,
+        dedupe: bool = False,
+        log_skips: bool = False,
+    ) -> List[Path]:
+        files: List[Path] = []
+        seen: Set[Path] = set()
+        for candidate in candidates:
+            path = Path(candidate)
+            resolved = path
+            try:
+                resolved = path.resolve()
+            except (FileNotFoundError, RuntimeError):
+                resolved = path
+
+            if dedupe and resolved in seen:
+                continue
+
+            if not path.exists():
+                if log_skips:
+                    logger.warning('Skipping %s: file does not exist', path)
+                continue
+            if not path.is_file():
+                if log_skips:
+                    logger.warning('Skipping %s: not a file', path)
+                continue
+            if path.suffix.lower() not in self.IMAGE_EXTS:
+                if log_skips:
+                    logger.warning('Skipping %s: unsupported extension', path)
+                continue
+
+            if dedupe:
+                seen.add(resolved)
+            files.append(path)
+        return files
 
     def _process_one(self, path: Path) -> None:
         """
@@ -138,6 +195,16 @@ class SelfieSorter:
 
         dest_path = self._unique_dest(dest_dir / path.name)
         shutil.move(str(path), dest_path)
+
+        if self.cfg.write_censored and self.censor:
+            censored_base = dest_path.with_name(
+                f"{dest_path.stem}{self.cfg.censored_suffix}{dest_path.suffix}"
+            )
+            censored_path = self._unique_dest(censored_base)
+            try:
+                self.censor.create_copy(dest_path, censored_path)
+            except Exception:  # pragma: no cover - defensive
+                logger.warning('Failed to create censored copy for %s', dest_path, exc_info=True)
 
         if self.cfg.write_sidecar:
             meta = {


### PR DESCRIPTION
## Summary
- expand the image censor helper to support pixelated, blurred, or black-box overlays with configurable strength and label
- expose new CLI and configuration switches for choosing censor style/label and document the usage in the README

## Testing
- python -m selfie_sorter.cli --help

------
https://chatgpt.com/codex/tasks/task_e_68d895bf7268832d9ba4db50bfde482d

## Summary by Sourcery

Add flexible image censoring functionality with configurable styles, strength, and labels; expose new CLI switches for generating censor copies and retroactive censorship; enhance file input options and progress reporting

New Features:
- Implement pixelated, blurred, and black-box censoring styles via ImageCensor and censor_sorted_tree utilities
- Add CLI options to generate censored copies (--censor-copies, --censor-style, --censor-strength, --censor-label, --censor-suffix, --censor-dir) and retroactively censor existing sorted trees (--censor-existing)
- Support explicit file inputs via --files instead of always scanning the input directory

Enhancements:
- Introduce yaspin spinner and tqdm progress bar for file collection, sorting, and censoring
- Refactor file gathering and filtering into dedicated _gather_files and _filter_supported_files methods

Build:
- Bump version to 1.0.0-dev.3 and add tqdm and yaspin dependencies

Documentation:
- Update README with usage examples for new censoring and file scanning flags